### PR TITLE
Remove hdd_errors filter from Heka metadata

### DIFF
--- a/rsyslog/meta/heka.yml
+++ b/rsyslog/meta/heka.yml
@@ -33,15 +33,3 @@ log_collector:
       differentiator: [ 'system.', 'haproxy' ]
       decoder: "syslog_decoder"
       splitter: "TokenSplitter"
-  filter:
-    hdd_errors:
-      engine: sandbox
-      module_file: /usr/share/lma_collector/filters/hdd_errors_counter.lua
-      module_dir: /usr/share/lma_collector/common;/usr/share/heka/lua_modules
-      preserve_data: false
-      message_matcher: "Type == 'log' && Logger == 'system.kern'"
-      ticker_interval: 10
-      config:
-        grace_interval: 10
-        patterns: "/error%s.+([sv]d[a-z][a-z]?)%d?/ /([sv]d[a-z][a-z]?)%d?.+%serror/"
-        hostname: '{{ grains.host }}'


### PR DESCRIPTION
The filter is moved to the Heka formula instead with the other
log_collector filters.