### PR TITLE
Remove jinja maping for user/group/umask/createmode

### DIFF
--- a/rsyslog/map.jinja
+++ b/rsyslog/map.jinja
@@ -26,43 +26,23 @@ Debian:
       /var/log/syslog:
         sync: false
         filter: "*.*;auth,authpriv.none"
-        owner: syslog
-        group: adm
-        createmode: "0640"
-        umask: "0022"
         enabled: true
       /var/log/auth.log:
         sync: true
         filter: "auth,authpriv.*"
-        owner: syslog
-        group: adm
-        createmode: "0640"
-        umask: "0022"
         enabled: true
       /var/log/kern.log:
         sync: false
         filter: "kern.*"
-        owner: syslog
-        group: adm
-        createmode: "0640"
-        umask: "0022"
         enabled: true
       /var/log/mail.log:
         sync: false
         filter: "mail.*"
-        owner: syslog
-        group: adm
-        createmode: "0640"
-        umask: "0022"
         enabled: true
       /var/log/mail.err:
         sync: false
         action: /var/log/mail.err
         filter: mail.err
-        owner: syslog
-        group: adm
-        createmode: "0640"
-        umask: "0022"
         enabled: true
     console:
       wall:
@@ -105,50 +85,26 @@ RedHat:
       /var/log/messages:
         sync: true
         filter: "*.info;mail.none;authpriv.none;cron.none"
-        owner: root
-        group: adm
-        createmode: "0640"
-        umask: "0022"
         enabled: true
       /var/log/secure:
         sync: true
         filter: "authpriv.*"
-        owner: root
-        group: adm
-        createmode: "0640"
-        umask: "0022"
         enabled: true
       /var/log/maillog:
         sync: true
         filter: "mail.*"
-        owner: root
-        group: adm
-        createmode: "0640"
-        umask: "0022"
         enabled: true
       /var/log/cron:
         sync: true
         filter: "cron.*"
-        owner: root
-        group: adm
-        createmode: "0640"
-        umask: "0022"
         enabled: true
       /var/log/spooler:
         sync: true
         filter: "uucp,news.crit"
-        owner: root
-        group: adm
-        createmode: "0640"
-        umask: "0022"
         enabled: true
       /var/log/boot.log:
         sync: false
         filter: "local7.*"
-        owner: root
-        group: adm
-        createmode: "0640"
-        umask: "0022"
         enabled: true
 {%- endload %}
 {%- set global = salt['grains.filter_by'](base_defaults, merge=salt['pillar.get']('rsyslog:client')) %}


### PR DESCRIPTION
in rsyslog/files/rsyslog.default.conf we have entries like {% if config.owner is defined -%} but in the jinja map these values are populated so the user has not option _not_ to specify these. Trying to set "owner: undef<cr><lf>" and "owner: <cr><lf>" results in owner = "undef" or owner = "None" resulting in these values being defined.