### PR TITLE
Patch 2

### DIFF
--- a/rsyslog/files/rsyslog.default.conf
+++ b/rsyslog/files/rsyslog.default.conf
@@ -26,18 +26,25 @@ $SystemLogRateLimitInterval {{ global.system_log_rate_limit_interval }}
 {% if global.system_log_rateLimit_burst is defined -%}
 $SystemLogRateLimitBurst {{ global.system_log_rateLimit_burst }}
 {% endif -%}
+{% if global.perm_dir is defined -%}
 $DirCreateMode {{ global.perm_dir }}
+{% endif -%}
+{% if global.run_user is defined -%}
 $PrivDropToUser {{ global.run_user }}
+{% endif -%}
+{% if global.run_group is defined -%}
 $PrivDropToGroup {{ global.run_group }}
+{% endif -%}
+
 $WorkDirectory {{ global.spool_dir }}
 
 {% if global.format is defined -%}
+{% if global.format.template is defined -%}
 $Template {{ global.format.name }}, "{{ global.format.template }}"
-$ActionFileDefaultTemplate {{ global.format.name }}
-{% else -%}
-$template RSYSLOG_TraditionalFileFormat
-$ActionFileDefaultTemplate RSYSLOG_TraditionalFileFormat
 {% endif -%}
+$ActionFileDefaultTemplate {{ global.format.name }}
+{% endif -%}
+
 
 {# Additional configurations should be included after defining the global format otherwise they won't benefit from it #}
 $IncludeConfig {{ global.rsyslog_d }}/*.conf

--- a/rsyslog/map.jinja
+++ b/rsyslog/map.jinja
@@ -11,16 +11,12 @@ Debian:
   non_kernel_facility: true
   msg_reduction: true
   manage_file_perms: true
-  perm_dir: "0755"
-  run_user: syslog
-  run_group: syslog
   rsyslog_d: /etc/rsyslog.d
   modules:
   - imuxsock
   - imklog
   format:
     name: Rfc3164Log
-    template: '<%PRI%>%TIMESTAMP:::date-rfc3339% %HOSTNAME% %syslogtag:1:32%%msg:::sp-if-no-1st-sp%%msg%\n'
   output:
     file:
       /var/log/syslog:
@@ -79,6 +75,7 @@ Debian:
         filter: "*.*"
         enabled: false
 RedHat:
+RedHat:
   pkgs:
   - rsyslog
   service:
@@ -90,16 +87,12 @@ RedHat:
   non_kernel_facility: false
   msg_reduction: false
   manage_file_perms: true
-  perm_dir: "0755"
-  run_user: root
-  run_group: root
   rsyslog_d: /etc/rsyslog.d
   modules:
   - imjournal
   - imuxsock
   format:
     name: Rfc3164Log
-    template: '<%PRI%>%TIMESTAMP:::date-rfc3339% %HOSTNAME% %syslogtag:1:32%%msg:::sp-if-no-1st-sp%%msg%\n'
   output:
     file:
       /var/log/messages:


### PR DESCRIPTION
I may not wish to specify these values, but these are being forced. For example, you cannot reproduce the CentOS 7 default configuration file that ships from the distro. This change will allow that.