### PR TITLE
Upate for minion 2019.2.2

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,31 +31,31 @@ Rsyslog service with precise timestamps, severity, facility.
           file:
             -/var/log/syslog:
               filter: *.*;auth,authpriv.none
-              owner: syslog
+              user: syslog
               group: adm
               createmode: 0640
               umask: 0022
             /var/log/auth.log:
               filter: auth,authpriv.*
-              owner: syslog
+              user: syslog
               group: adm
               createmode: 0640
               umask: 0022
             -/var/log/kern.log:
               filter: kern.*
-              owner: syslog
+              user: syslog
               group: adm
               createmode: 0640
               umask: 0022
            -/var/log/mail.log:
               filter: mail.*
-              owner: syslog
+              user: syslog
               group: adm
               createmode: 0640
               umask: 0022
             /var/log/mail.err:
               filter: mail.err
-              owner: syslog
+              user: syslog
               group: adm
               createmode: 0640
               umask: 0022
@@ -65,7 +65,7 @@ Rsyslog service with precise timestamps, severity, facility.
               filter: "daemon.*;mail.*; news.err; *.=debug;*.=info;*.=notice;*.=warn":
            -/var/log/your-app.log:
               filter: "if $programname startswith 'your-app' then"
-              owner: syslog
+              user: syslog
               group: adm
               createmode: 0640
               umask: 0022

--- a/rsyslog/client.sls
+++ b/rsyslog/client.sls
@@ -85,6 +85,7 @@ rsyslog_cacert_chain_client:
   - mode: "{{ type['createmode'] }}"
   - owner: {{ type['owner'] }}
   - group: {{ type['group'] }}
+  - relpace: False
   - watch:
     - file: /etc/rsyslog.conf
   - watch_in:

--- a/rsyslog/client.sls
+++ b/rsyslog/client.sls
@@ -35,7 +35,7 @@ rsyslog_public_cert_client:
   file.managed:
   - name: {{ cert_file }}
   - contents_pillar: rsyslog:client:ssl:cert
-  - owner: {{ global.run_user }}
+  - user: {{ global.run_user }}
   - group: {{ global.run_group }}
   - mode: 0400
   - require:
@@ -51,7 +51,7 @@ rsyslog_private_key_client:
   file.managed:
   - name: {{ key_file }}
   - contents_pillar: rsyslog:client:ssl:key
-  - owner: {{ global.run_user }}
+  - user: {{ global.run_user }}
   - group: {{ global.run_group }}
   - mode: 0400
   - require:
@@ -67,7 +67,7 @@ rsyslog_cacert_chain_client:
   file.managed:
   - name: {{ ca_file }}
   - contents_pillar: rsyslog:client:ssl:cacert_chain
-  - owner: {{ global.run_user }}
+  - user: {{ global.run_user }}
   - group: {{ global.run_group }}
   - mode: 0400
   - require:
@@ -83,9 +83,9 @@ rsyslog_cacert_chain_client:
 {{ output }}:
   file.managed:
   - mode: "{{ type['createmode'] }}"
-  - owner: {{ type['owner'] }}
+  - user: {{ type['user'] }}
   - group: {{ type['group'] }}
-  - relpace: False
+  - replace: False
   - watch:
     - file: /etc/rsyslog.conf
   - watch_in:

--- a/rsyslog/common.sls
+++ b/rsyslog/common.sls
@@ -1,7 +1,7 @@
 {%- from "rsyslog/map.jinja" import global with context %}
 
 rsyslog_packages:
-  pkg.latest:
+  pkg.installed:
   - names: {{ global.pkgs }}
 
 rsyslog_service:

--- a/rsyslog/files/rsyslog.default.conf
+++ b/rsyslog/files/rsyslog.default.conf
@@ -96,8 +96,8 @@ $Template {{ name|replace('/', '_') }}, "{{ config.template }}"
 
 {%- macro rsyslog_output_file(files) -%}
 {%- for name, config in files.items() %}
-{% if config.owner is defined -%}
-$FileOwner {{ config['owner'] }}
+{% if config.user is defined -%}
+$FileOwner {{ config['user'] }}
 {% endif -%}
 {% if config.group is defined -%}
 $FileGroup {{ config['group'] }}

--- a/rsyslog/map.jinja
+++ b/rsyslog/map.jinja
@@ -26,7 +26,7 @@ Debian:
       /var/log/syslog:
         sync: false
         filter: "*.*;auth,authpriv.none"
-        owner: syslog
+        user: syslog
         group: adm
         createmode: "0640"
         umask: "0022"
@@ -34,7 +34,7 @@ Debian:
       /var/log/auth.log:
         sync: true
         filter: "auth,authpriv.*"
-        owner: syslog
+        user: syslog
         group: adm
         createmode: "0640"
         umask: "0022"
@@ -42,7 +42,7 @@ Debian:
       /var/log/kern.log:
         sync: false
         filter: "kern.*"
-        owner: syslog
+        user: syslog
         group: adm
         createmode: "0640"
         umask: "0022"
@@ -50,7 +50,7 @@ Debian:
       /var/log/mail.log:
         sync: false
         filter: "mail.*"
-        owner: syslog
+        user: syslog
         group: adm
         createmode: "0640"
         umask: "0022"
@@ -59,7 +59,7 @@ Debian:
         sync: false
         action: /var/log/mail.err
         filter: mail.err
-        owner: syslog
+        user: syslog
         group: adm
         createmode: "0640"
         umask: "0022"
@@ -105,7 +105,7 @@ RedHat:
       /var/log/messages:
         sync: true
         filter: "*.info;mail.none;authpriv.none;cron.none"
-        owner: root
+        user: root
         group: adm
         createmode: "0640"
         umask: "0022"
@@ -113,7 +113,7 @@ RedHat:
       /var/log/secure:
         sync: true
         filter: "authpriv.*"
-        owner: root
+        user: root
         group: adm
         createmode: "0640"
         umask: "0022"
@@ -121,7 +121,7 @@ RedHat:
       /var/log/maillog:
         sync: true
         filter: "mail.*"
-        owner: root
+        user: root
         group: adm
         createmode: "0640"
         umask: "0022"
@@ -129,7 +129,7 @@ RedHat:
       /var/log/cron:
         sync: true
         filter: "cron.*"
-        owner: root
+        user: root
         group: adm
         createmode: "0640"
         umask: "0022"
@@ -137,7 +137,7 @@ RedHat:
       /var/log/spooler:
         sync: true
         filter: "uucp,news.crit"
-        owner: root
+        user: root
         group: adm
         createmode: "0640"
         umask: "0022"
@@ -145,7 +145,7 @@ RedHat:
       /var/log/boot.log:
         sync: false
         filter: "local7.*"
-        owner: root
+        user: root
         group: adm
         createmode: "0640"
         umask: "0022"


### PR DESCRIPTION
Applied 3 changes:

1. Changed pkg.latest to pkg.installed to prevent unexpected package updates. Not always administrators need autoupdate for system packages during salt execution. Administrator should have option to control system packages update manually.

2. Added "**replace: False**" to the file.managed to prevent warnings that contentc is not defined.

3. Added parameter owner to user as required by last salt version. Prevent warnings like:
```
# salt-call state.apply rsyslog
[WARNING ] Use of argument owner found, "owner" is invalid, please use "user"
[WARNING ] Use of argument owner found, "owner" is invalid, please use "user"
[WARNING ] Use of argument owner found, "owner" is invalid, please use "user"
[WARNING ] Use of argument owner found, "owner" is invalid, please use "user"
[WARNING ] Use of argument owner found, "owner" is invalid, please use "user"
[WARNING ] Use of argument owner found, "owner" is invalid, please use "user"
```